### PR TITLE
README file's links in the Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,8 @@
-FuXi is a Python-based, bi-directional logical reasoning system for the
-semantic web.
+FuXi is a Python-based, bi-directional logical reasoning system for the semantic web.
 
-FuXi aims to be the engine for contemporary expert systems based on the
-Semantic Web technologies. It is named after the
-`first <http://en.wikipedia.org/wiki/Fu_Hsi>`_ of the Three Sovereigns
-of ancient China.
+FuXi aims to be the engine for contemporary expert systems based on the Semantic Web technologies.
+It is named after the [first](http://en.wikipedia.org/wiki/Fu_Hsi) of the Three Sovereigns of ancient China.
 
-It originally formed from an idea to express the underlying symbols (and
-their relationships) in the Yi Jing or Zhou Yi ("The Book of Changes")
-in OWL and RDF in order to reason over their structural relationships.
+It originally formed from an idea to express the underlying symbols (and their relationships) in the Yi Jing or Zhou Yi ("The Book of Changes") in OWL and RDF in order to reason over their structural relationships.
 
-For an overview of the architecture, please read
-`FuXi Overview <http://code.google.com/p/fuxi/wiki/Overview>`_ and
-`FuXi User Manual <http://code.google.com/p/fuxi/wiki/FuXiUserManual>`_
-for more information.
-
+For an overview of the architecture, please read [FuXi Overview](http://code.google.com/p/fuxi/wiki/Overview) and [FuXi User Manual](http://code.google.com/p/fuxi/wiki/FuXiUserManual) for more information.


### PR DESCRIPTION
The file extension suggest that it contains a description in the Markdown syntax. However, the links followed the reStructuredText (reST) syntax.
