### PR TITLE
HashablePatternList bug: when a rule has a Literal with whitespace in it, rdflib logs warnings

### DIFF
--- a/test/test_network_pattern_list.py
+++ b/test/test_network_pattern_list.py
@@ -1,0 +1,30 @@
+import unittest
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+from FuXi.Rete.Network import HashablePatternList
+from rdflib import URIRef, Literal
+import rdflib.term
+
+class TestHashablePatternList(unittest.TestCase):
+    def setUp(self):
+        super(TestHashablePatternList, self).setUp()
+        
+        self.oldWarning = rdflib.term._LOGGER.warning
+        def stopOnWarning(msg):
+            raise ValueError("this warning was logged: %s" % msg)
+        rdflib.term._LOGGER.warning = stopOnWarning
+        
+    def tearDown(self):
+        super(TestHashablePatternList, self).tearDown()
+        rdflib.term._LOGGER.warning = self.oldWarning
+        
+    def testCombineUriAndLiteral(self):
+        # This is a simplified version of input that happens in real usage with a rule like this:
+        # { ?c :p1 ?uri . } => { ?c :p2 (" " ?uri) . } .
+        hpl = HashablePatternList(items=[(URIRef('http://example.com/'),),
+                                         (Literal(' '),)])
+        hash(hpl)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
See my post at https://groups.google.com/forum/#!topic/fuxi-discussion/43arTZCbSPo for more context and  demo. This **hash** rewrite lets hash() do the mixing of the values instead of ever using +, which should perform faster and avoid the original bug. However, this will make some things that hashed the same before now have different hash values (and vice versa, in even rarer cases). 

Using hash results to test equality is a bad practice in the first place, but I don't know the code well enough to fix that. It SEEMS like **eq** should be comparing the incoming 'items' values, after whatever canonicalization (sorting, ignore bnodes, etc) is supposed to happen.
